### PR TITLE
Handle merges

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,3 +19,8 @@ jobs:
       - name: Debug
         run: |
           echo "Has changes: ${{ steps.check-changes.outputs.changed }}"
+
+      - name: Test
+        if: steps.rcheck-changes.outputs.changed == '1'
+        run: |
+          echo "Files did change!"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ SHA=$1
 PATHSPEC=$2
 
 function check() {
-  if [[ -z "$(git diff-tree --no-commit-id --name-only -r $SHA $PATHSPEC)" ]];
+  if [[ -z "$(git diff-tree --no-commit-id --name-only -r -m $SHA $PATHSPEC)" ]];
   then
     echo "0"
   else


### PR DESCRIPTION
Add `-m` flag to  `git diff-tree` command so that merge diffs cause the `changed` output to evaluate to `true`.