### PR TITLE
Patch output setting.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,4 +16,4 @@ function check() {
   fi
 }
 
-echo ::set-output name=changed::$(check)
+echo "changed=$(check)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Replaces the use of  `set-ouptut` that has been deprecated since 24-July-2023 with the recommended use of environment files.

See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/